### PR TITLE
Optimize further.

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -246,7 +246,7 @@ def region_grower_callback(sender, app_data):
         mask = STATE["rvk"]["model"].segmentation_mask.data
         sigma_d = dpg.get_value("sigma_d")
         sigma_f = dpg.get_value("sigma_f")
-        mask = run.run_region_grower(mask, STATE["fg"], sigma_d, sigma_f)
+        mask = run.run_region_grower(mask, STATE["fg"], STATE["og_density_grid"].cuda(), sigma_d, sigma_f)
         times.append(time.time())
         STATE["prev_mask"] = STATE["rvk"]["model"].segmentation_mask.cpu()
         STATE["rvk"]["model"].segmentation_mask = torch.nn.Parameter(mask, requires_grad=False)
@@ -265,7 +265,7 @@ if __name__ == "__main__":
         STATE["dino_dim"] = args.dino_dim
         STATE["cfg"], STATE["data_dict"], STATE["device"] = run.do_setup(args)
         STATE["rvk"], STATE["optimizer"], STATE["start"] = run.load_model(args, STATE["cfg"], STATE["data_dict"], STATE["device"])
-        STATE["og_density_grid"] = STATE["rvk"]["model"].density.grid.clone().cpu()
+        STATE["og_density_grid"] = STATE["rvk"]["model"].density.grid.clone()
         STATE["positive_buffer"] = STATE["rvk"]["model"].segmentation_mask.clone()
         STATE["negative_buffer"] = 1.0 - STATE["rvk"]["model"].segmentation_mask.clone()
         STATE["fg"], STATE["fg_kmeans"], STATE["valid_idx"] = run.reconstruct_feature_grid(STATE["rvk"], STATE["dino_dim"])

--- a/lib/grid.py
+++ b/lib/grid.py
@@ -239,7 +239,7 @@ class MaskGrid(nn.Module):
         return f'mask.shape=list(self.mask.shape)'
 
 
-def get_dense_grid_batch_processing(tensorf: TensoRFGrid):
+def get_dense_grid_batch_processing(tensorf: TensoRFGrid, num_dim: int=64):
     """
     Expects the tensorf to be already on device and processes it on device batchwise.
     Not transferring from cpu to avoid repeated transfers from cpu to device
@@ -249,7 +249,7 @@ def get_dense_grid_batch_processing(tensorf: TensoRFGrid):
     # result_grid = torch.zeros([1, tensorf.channels, *tensorf.world_size], dtype=tensorf.xy_plane.dtype).cpu()
     start_time = time.time()
     # result_grid = torch.stack([torch.zeros([1, *tensorf.world_size], dtype=tensorf.x_vec.dtype).cpu() for _ in range(tensorf.channels)], dim=1)
-    result_grid = torch.zeros([1, tensorf.channels, *tensorf.world_size], dtype=tensorf.x_vec.dtype)
+    result_grid = torch.zeros([1, num_dim, *tensorf.world_size], dtype=tensorf.x_vec.dtype)
     print("Time taken for initializing the grid", time.time() - start_time)
 
     # created y batches just in case if needed
@@ -269,7 +269,7 @@ def get_dense_grid_batch_processing(tensorf: TensoRFGrid):
                     torch.einsum('ryz,rx->rxyz', tensorf.yz_plane[0, :, start_y:end_y, start_z:end_z], tensorf.x_vec[0,:,start_x:end_x,0]),
                 ])
                 sub_grid = torch.einsum('rxyz,rc->cxyz', feat, tensorf.f_vec)[None]
-                result_grid[:, :, start_x:end_x, start_y:end_y, start_z:end_z] = sub_grid
+                result_grid[:, :, start_x:end_x, start_y:end_y, start_z:end_z] = sub_grid[:, :num_dim, :, :, :]
     return result_grid
 
 if __name__ == "__main__":

--- a/run.py
+++ b/run.py
@@ -1102,8 +1102,8 @@ def query_kmeans_clustering(faiss_kmeans, fg_kmeans, valid_idx, threshold, xyz):
     return mask
 
 @torch.no_grad()
-def run_region_grower(mask, fg, sigma_d, sigma_f):
-    mask = dev_region_grower_mask(mask, fg, sigma_d, sigma_f, False)
+def run_region_grower(mask, fg, density, sigma_d, sigma_f):
+    mask = dev_region_grower_mask(mask, fg, density, sigma_d, sigma_f, False)
     torch.cuda.empty_cache()
     return mask
 

--- a/run.py
+++ b/run.py
@@ -85,6 +85,8 @@ def config_parser():
                         help='file path for the feature vector to use for segmentation')
     parser.add_argument("--stop_at", type=int,
                         help='at what iteration to stop training.')
+    parser.add_argument("--dino_dim", type=int, default=64,
+                        help='number of dimensions to use for segmentaiton in the interactive mode.')
     return parser
 
 
@@ -1051,18 +1053,21 @@ def render_images(render_viewpoints_kwargs: dict, cfg, data_dict: dict, imageset
     return rgbs, features
 
 @torch.no_grad()
-def reconstruct_feature_grid(render_viewpoints_kwargs):
+def reconstruct_feature_grid(render_viewpoints_kwargs, num_dim=64):
     model = render_viewpoints_kwargs['model']
 
     f_k0 = model.f_k0.cuda()
-    fg = get_dense_grid_batch_processing(f_k0).cuda()
+    fg = get_dense_grid_batch_processing(f_k0, num_dim).cuda()
 
-    fg_kmeans = fg.clone()
+    density = model.density.grid
+    valid_idx = (density > 0.1).squeeze().squeeze()
+
+    fg_kmeans = fg.cpu().clone()
     fg_kmeans = fg_kmeans.squeeze(0).permute(1, 2, 3, 0) # x, y, z, 64
-    fg_kmeans = fg_kmeans.reshape(-1, 64)
-    fg_kmeans = fg_kmeans.cpu().contiguous()
+    fg_kmeans = fg_kmeans[valid_idx.cpu()]
+    fg_kmeans = fg_kmeans.contiguous()
 
-    return torch.nn.functional.pad(fg, [1] * 6), fg_kmeans
+    return torch.nn.functional.pad(fg, [1] * 6), fg_kmeans, valid_idx
 
 @torch.no_grad()
 def do_kmeans_clustering(mask_index, feature_image):
@@ -1092,8 +1097,8 @@ def do_kmeans_clustering_multiview(indices, fimages):
     return faiss_kmeans
 
 @torch.no_grad()
-def query_kmeans_clustering(faiss_kmeans, fg_kmeans, threshold, xyz):
-    mask = query_kmeans(faiss_kmeans, fg_kmeans, threshold, xyz)
+def query_kmeans_clustering(faiss_kmeans, fg_kmeans, valid_idx, threshold, xyz):
+    mask = query_kmeans(faiss_kmeans, fg_kmeans, valid_idx, threshold, xyz)
     return mask
 
 @torch.no_grad()


### PR DESCRIPTION
- Added support to interactively segment using any top d of the 64 dino
  dimensions.
- Removed the sudden GPU memory peak due to the fg_kmeans grid. Now that
  processing happens on the CPU which means slightly slower
preprocessing. No effect on interactive segmentation timings.
- Added density based pruning for fg_kmeans. Around 40% of the grid is
  used now. Leads to around 3x speedup for getting HCR.
- Added density pruning for region growing as well. Again a 3x speedup.